### PR TITLE
Fixed react-script version to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-dom": "16.12.0",
     "react-google-maps": "9.4.5",
     "react-router-dom": "5.1.2",
-    "react-scripts": "3.3.1",
+    "react-scripts": "3.4.1",
     "reactstrap": "8.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
fixed react-verion to 3.4.1, if use react-script:3.3.1 return the current error:

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:117:11)
    at Object.join (path.js:375:7)
    at noopServiceWorkerMiddleware (C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\react-dev-utils\noopServiceWorkerMiddleware.js:14:26)
    at Layer.handle [as handle_request] (C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\express\lib\router\layer.js:95:5)
    at trim_prefix (C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\express\lib\router\index.js:317:13)
    at C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\express\lib\router\index.js:284:7
    at Function.process_params (C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\express\lib\router\index.js:335:12)
    at next (C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\express\lib\router\index.js:275:10)
    at launchEditorMiddleware (C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\react-dev-utils\errorOverlayMiddleware.js:20:7)
    at Layer.handle [as handle_request] (C:\Users\Gabriel\Documents\Projetos\argon-dashboard-react\node_modules\express\lib\router\layer.js:95:5)