### PR TITLE
Update react-scripts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-dom": "16.12.0",
     "react-google-maps": "9.4.5",
     "react-router-dom": "5.1.2",
-    "react-scripts": "3.3.1",
+    "react-scripts": "3.4.0",
     "reactstrap": "8.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When running this repository, such error occurs:
```
[ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string.
```

Changing react-scripts to 3.4.0 fixed it.